### PR TITLE
Add use-case-mappings

### DIFF
--- a/assertions/use-case-mappings/src/FunctionCallInputs.sol
+++ b/assertions/use-case-mappings/src/FunctionCallInputs.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {PhEvm} from "credible-std/PhEvm.sol";
+import {Assertion} from "credible-std/Assertion.sol";
+
+contract Protocol {
+    mapping(address => uint256) public balances;
+
+    function transfer(address to, uint256 amount) public {
+        balances[msg.sender] -= amount;
+        balances[to] += amount;
+    }
+
+    function mint(address to, uint256 amount) public {
+        balances[to] += amount;
+    }
+}
+
+/// It is possible to get the inputs of all calls within a transaction and their respective
+/// call data. The struct returned can be found here:
+/// https://github.com/phylaxsystems/credible-std/blob/f4dfdfb8b0f160f7350dc343e65e41993478f33c/src/PhEvm.sol#L16-L39
+/// Input data can often be used to assert the expected outcome of a function call.
+/// Note: It is typical that there can be multiple state changing function calls in a single transaction.
+/// The assertion should consider this.
+/// Note: The returned array is ordered by the order of the calls in the transaction.
+/// Currently, it is only possible to fetch call inputs for a specific function selector.
+/// There is no ordering guarantee between call inputs of different function selectors.
+contract FunctionCallInputsAssertion is Assertion {
+    Protocol public protocol;
+    mapping(address => int256) public balanceChanges;
+    address[] changedAddresses;
+
+    constructor(Protocol protocol_) {
+        protocol = protocol_;
+    }
+
+    function triggers() public view override {
+        registerCallTrigger(this.assertionFunctionCallInputs.selector);
+    }
+
+    function assertionFunctionCallInputs() public {
+        PhEvm.CallInputs[] memory callInputs = ph.getCallInputs(address(protocol), protocol.transfer.selector);
+
+        for (uint256 i = 0; i < callInputs.length; i++) {
+            address from = callInputs[i].caller;
+            (address to, uint256 amount) = abi.decode(callInputs[i].input, (address, uint256));
+            // There is an edge case where the balanceChanges has gone back to 0
+            // In this case, it would be duplicated in the changedAddresses array
+            // Additional flags can remove duplicates
+            if (balanceChanges[from] == 0) {
+                changedAddresses.push(from);
+            }
+            if (balanceChanges[to] == 0) {
+                changedAddresses.push(to);
+            }
+            balanceChanges[from] -= int256(amount);
+            balanceChanges[to] += int256(amount);
+        }
+
+        uint256 preBalance;
+        uint256 absDiff;
+
+        for (uint256 i = 0; i < changedAddresses.length; i++) {
+            ph.forkPreState();
+            preBalance = protocol.balances(changedAddresses[i]);
+            ph.forkPostState();
+
+            if (balanceChanges[changedAddresses[i]] >= 0) {
+                absDiff = uint256(balanceChanges[changedAddresses[i]]);
+                require(protocol.balances(changedAddresses[i]) == preBalance + absDiff, "Balance change mismatch");
+            } else {
+                absDiff = uint256(balanceChanges[changedAddresses[i]] * -1);
+                require(protocol.balances(changedAddresses[i]) == preBalance - absDiff, "Balance change mismatch");
+            }
+        }
+    }
+}

--- a/assertions/use-case-mappings/src/ReadLogs.sol
+++ b/assertions/use-case-mappings/src/ReadLogs.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Assertion} from "credible-std/Assertion.sol";
+import {PhEvm} from "credible-std/PhEvm.sol";
+
+contract Protocol {
+    event Transfer(address from, address to, uint256 amount);
+
+    mapping(address => uint256) public balances;
+
+    function transfer(address to, uint256 amount) public {
+        balances[msg.sender] -= amount;
+        balances[to] += amount;
+        emit Transfer(msg.sender, to, amount);
+    }
+
+    function mint(address to, uint256 amount) public {
+        balances[to] += amount;
+        emit Transfer(address(0), to, amount);
+    }
+}
+
+/// It is possible to get the logs of all transactions within a transaction.
+/// The struct returned can be found here:
+/// https://github.com/phylaxsystems/credible-std/blob/f4dfdfb8b0f160f7350dc343e65e41993478f33c/src/PhEvm.sol#L6-L13
+/// Log data can often be used to assert the expected outcome of state changes.
+/// Note: It needs to be made sure that logs are emitted for every corresponding state change.
+contract ReadLogsAssertion is Assertion {
+    Protocol public protocol;
+
+    constructor(Protocol protocol_) {
+        protocol = protocol_;
+    }
+
+    function triggers() public view override {
+        registerCallTrigger(this.assertionReadLogs.selector);
+    }
+
+    mapping(address => int256) public balanceChanges;
+    address[] changedAddresses;
+
+    function assertionReadLogs() public {
+        PhEvm.Log[] memory logs = ph.getLogs();
+
+        for (uint256 i = 0; i < logs.length; i++) {
+            (address from, address to, uint256 amount) = abi.decode(logs[i].data, (address, address, uint256));
+            // There is an edge case where the changedBalance has gone back to 0
+            // In this case, it would be duplicated in the changedAddresses array
+            // Additional flags can remove duplicates
+            if (balanceChanges[from] == 0) {
+                changedAddresses.push(from);
+            }
+            if (balanceChanges[to] == 0) {
+                changedAddresses.push(to);
+            }
+            balanceChanges[from] -= int256(amount);
+            balanceChanges[to] += int256(amount);
+        }
+
+        uint256 preBalance;
+        uint256 absDiff;
+
+        for (uint256 i = 0; i < changedAddresses.length; i++) {
+            ph.forkPreState();
+            preBalance = protocol.balances(changedAddresses[i]);
+            ph.forkPostState();
+
+            if (balanceChanges[changedAddresses[i]] > 0) {
+                absDiff = uint256(balanceChanges[changedAddresses[i]]);
+                require(protocol.balances(changedAddresses[i]) == preBalance + absDiff, "Balance change mismatch");
+            } else {
+                absDiff = uint256(balanceChanges[changedAddresses[i]] * -1);
+                require(protocol.balances(changedAddresses[i]) == preBalance - absDiff, "Balance change mismatch");
+            }
+        }
+    }
+}

--- a/assertions/use-case-mappings/src/StateChanges.sol
+++ b/assertions/use-case-mappings/src/StateChanges.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Assertion} from "credible-std/Assertion.sol";
+import {PhEvm} from "credible-std/PhEvm.sol";
+
+contract MonotonicallyIncreasingValue {
+    uint256 public value;
+
+    function setValue(uint256 value_) external {
+        value = value_;
+    }
+}
+
+/// It is possible to get all values assigned to any slot within a transaction.
+/// This is very helpful if you want to test that state invariants were never violated, even intra tx.
+/// Note: Sometimes it is useful to know the inputs of a function call which led to the state change.
+/// It should be noted that if the assertion queries call inputs and state changes separately (which there exists no other way right now),
+/// there is no guarantee that each index of the two arrays are related.
+/// Note: The returned array is ordered by the timely order of the state changes.
+contract StateChangesAssertion is Assertion {
+    MonotonicallyIncreasingValue public protocol;
+
+    constructor(MonotonicallyIncreasingValue protocol_) {
+        protocol = protocol_;
+    }
+
+    function triggers() public view override {
+        registerCallTrigger(this.assertionStateChanges.selector);
+    }
+
+    function assertionStateChanges() public view {
+        uint256[] memory changes = getStateChangesUint(address(protocol), 0x0);
+        for (uint256 i = 0; i < changes.length - 1; i++) {
+            require(changes[i] < changes[i + 1], "Value is not monotonically increasing");
+        }
+    }
+}

--- a/assertions/use-case-mappings/src/StorageLookup.sol
+++ b/assertions/use-case-mappings/src/StorageLookup.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Assertion} from "credible-std/Assertion.sol";
+import {PhEvm} from "credible-std/PhEvm.sol";
+
+contract Protocol {
+    address owner;
+
+    function setOwner(address owner_) public {
+        owner = owner_;
+    }
+}
+
+/// It is possible to get the value of any slot of the state before or after a transaction.
+/// This can be used to read private state variables.
+/// Note: It is possible to read the state before or after a transaction by using the forkPreState or forkPostState cheatcodes.
+contract StorageLookupAssertion is Assertion {
+    Protocol public protocol;
+
+    constructor(Protocol protocol_) {
+        protocol = protocol_;
+    }
+
+    function triggers() public view override {
+        registerCallTrigger(this.assertionStorageLookup.selector);
+    }
+
+    function assertionStorageLookup() public view {
+        address[] memory whitelist = new address[](2);
+        whitelist[0] = address(0x1);
+        whitelist[1] = address(0x2);
+
+        address owner = address(uint160(uint256(ph.load(address(protocol), bytes32(uint256(0))))));
+
+        for (uint256 i = 0; i < whitelist.length; i++) {
+            if (owner == whitelist[i]) {
+                return;
+            }
+        }
+
+        revert("Owner not in whitelist");
+    }
+}

--- a/assertions/use-case-mappings/src/unsupported/CallFrameContext.sol
+++ b/assertions/use-case-mappings/src/unsupported/CallFrameContext.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Assertion} from "credible-std/Assertion.sol";
+
+contract Protocol {
+    mapping(address => uint256) public balances;
+
+    function transfer(address to, uint256 amount) public {
+        balances[msg.sender] -= amount;
+        balances[to] += amount;
+    }
+
+    function mint(address to, uint256 amount) public {
+        balances[to] += amount;
+    }
+}
+
+// In this use case the assertion runs on context of a specific call instead of the whole transaction.
+// This is useful to assert properties about the state of the protocol at the time of a specific call.
+contract CallFrameContextAssertion is Assertion {
+    Protocol public protocol;
+
+    constructor(Protocol protocol_) {
+        protocol = protocol_;
+    }
+
+    function triggers() public view override {
+        /*
+        // unsupported for now
+        registerCallFrameTrigger(this.assertionCallFrameContext.selector, protocol.transfer.selector);
+        */
+    }
+
+    function assertionCallFrameContext() public view {
+        /*
+        // unsupported for now
+        // Returns the CallInputs for the specific call
+        PhEvm.CallFrameContext memory callFrameContext = ph.getCallFrameContext();
+
+        // Get the caller
+        address caller = callFrameContext.caller;
+
+        // Get the caller of the transaction
+        (address to, uint256 amount) = abi.decode(callFrameContext.input, (address, uint256));
+
+        ph.forkPreState();
+        // Read the state before the call
+
+        ph.forkPostState();
+        // Read the state after the call
+
+        // Assert the expected outcome here
+        */
+    }
+}

--- a/assertions/use-case-mappings/src/unsupported/ModifiedKeys.sol
+++ b/assertions/use-case-mappings/src/unsupported/ModifiedKeys.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Assertion} from "credible-std/Assertion.sol";
+
+contract Protocol {
+    mapping(address => uint256) public balances;
+
+    function transfer(address to, uint256 amount) public {
+        balances[msg.sender] -= amount;
+        balances[to] += amount;
+    }
+
+    function mint(address to, uint256 amount) public {
+        balances[to] += amount;
+    }
+}
+
+contract ModifiedKeysAssertion is Assertion {
+    Protocol public protocol;
+
+    constructor(Protocol protocol_) {
+        protocol = protocol_;
+    }
+
+    function triggers() public view override {
+        /*
+        registerStateChangeTrigger(this.assertionModifiedKeys.selector, 0x0);
+        */
+    }
+
+    function assertionModifiedKeys() public view {
+        /*
+        // unsupported for now
+        // Returns the keys that were modified in the transaction
+        address[] memory modifiedKeys = ph.getModifiedKeys(0x0);
+
+        for (uint256 i = 0; i < modifiedKeys.length; i++) {
+            address key = modifiedKeys[i];
+            uint256 balance = protocol.balances(key);
+
+            // Validate the value of the modified key here
+        }
+        */
+    }
+}

--- a/assertions/use-case-mappings/src/unsupported/SequencedFunctionCallInputs.sol
+++ b/assertions/use-case-mappings/src/unsupported/SequencedFunctionCallInputs.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Assertion} from "credible-std/Assertion.sol";
+
+contract Protocol {
+    mapping(address => uint256) public balances;
+
+    function transfer(address to, uint256 amount) public {
+        balances[msg.sender] -= amount;
+        balances[to] += amount;
+    }
+
+    function mint(address to, uint256 amount) public {
+        balances[to] += amount;
+    }
+}
+
+/// @notice This assertion is unsupported for now
+/// Currently only fetching function call inputs for a specific call is supported
+/// The order of function calls of different selectors might influence the expected outcome (resulting state) of the transaction.
+/// To properly validate transaction traces, function call inputs of different selectors need to be sequenced.
+contract SequencedFunctionCallInputsAssertion is Assertion {
+    Protocol public protocol;
+
+    constructor(Protocol protocol_) {
+        protocol = protocol_;
+    }
+
+    function triggers() public view override {
+        /*
+        registerCallFrameTrigger(this.assertionSequencedFunctionCallInputs.selector, protocol.transfer.selector);
+        */
+    }
+
+    function assertionSequencedFunctionCallInputs() public view {
+        /*
+        // unsupported for now
+        // Returns the function call inputs for the specific call
+        bytes4[] memory selectors = [Protocol.transfer.selector, Protocol.mint.selector];
+        PhEvm.CallInputs memory callInputs = ph.getCallInputs(address(protocol), selectors);
+
+        for (uint256 i = 0; i < callInputs.length; i++) {
+            if (callInputs[i].selector == Protocol.transfer.selector) {
+                processTransferCallInputs(callInputs[i]);
+            } else if (callInputs[i].selector == Protocol.mint.selector) {
+                processMintCallInputs(callInputs[i]);
+            }
+        }
+        */
+    }
+}

--- a/assertions/use-case-mappings/src/unsupported/SynchronizedStateChanges.sol
+++ b/assertions/use-case-mappings/src/unsupported/SynchronizedStateChanges.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Assertion} from "credible-std/Assertion.sol";
+
+contract Protocol {
+    uint256 public value1;
+    uint256 public value2;
+
+    function setValue1(uint256 value1_) public {
+        value1 = value1_;
+    }
+
+    function setValue2(uint256 value2_) public {
+        value2 = value2_;
+    }
+}
+
+/// @notice This assertion is unsupported for now
+/// When fetching state changes of a slot, it might be of interest what values other slots had at the time of the state change
+/// This is not possible to do with the current state change API
+/// State changes could be synchronized to capture the state of multiple slots at the time of a state change of any of them.
+contract SynchronizedStateChangesAssertion is Assertion {
+    Protocol public protocol;
+
+    constructor(Protocol protocol_) {
+        protocol = protocol_;
+    }
+
+    function triggers() public view override {
+        /*
+        registerStateChangeTrigger(this.assertionSynchronizedStateChanges.selector, 0x0);
+        */
+    }
+
+    function assertionSynchronizedStateChanges() public view {
+        /*
+        // unsupported for now
+        // Returns the state changes that were synchronized in the transaction
+        bytes32[2] memory synchronizedSlots = [0x0, 0x1];
+        uint256[][] memory stateChanges = ph.getSynchronizedStateChangesUint(synchronizedSlots);
+
+        for (uint256 i = 0; i < stateChanges.length; i++) {
+            uint256[] memory stateChange = stateChanges[i];
+
+            // validate the state changes here
+            // i.e. require(stateChange[0] != stateChange[1], "Values should be different");
+        }
+        */
+    }
+}

--- a/assertions/use-case-mappings/src/unsupported/UntrustedCallbacks.sol
+++ b/assertions/use-case-mappings/src/unsupported/UntrustedCallbacks.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Assertion} from "credible-std/Assertion.sol";
+
+contract Protocol {
+    uint256 public value;
+
+    function setValueWithCallback(uint256 value_) public {
+        value = value_;
+        (bool success,) = msg.sender.call("");
+        require(success, "Callback failed");
+    }
+}
+
+// Untrusted callbacks can influence the end state of the contract in unexpected ways.
+// In the example, the callback could recursively call the setter function,
+// making it nearly impossible to validate the end state.
+// In the future, assertions could be made aware of recursive function calls, helping to validate the end state.
+contract UntrustedCallbacksAssertion is Assertion {
+    Protocol public protocol;
+
+    constructor(Protocol protocol_) {
+        protocol = protocol_;
+    }
+
+    function triggers() public view override {
+        /*
+        registerCallFrameTrigger(this.assertionUntrustedCallbacks.selector, protocol.setValueWithCallback.selector);
+        */
+    }
+
+    function assertionUntrustedCallbacks() public view {
+        /*
+        CallInputs memory callInputs = getCallFrame();
+
+        // There is a untrusted callback in the function execution which could
+        // recursively call the setter function, letting the succeeding require fail.
+        // This is not supported yet.
+        (uint256 value) = abi.decode(callInputs.input, (uint256));
+        require(value == loadUint(0x0), "Value mismatch");
+        */
+    }
+}

--- a/assertions/use-case-mappings/test/FunctionCallInputs.t.sol
+++ b/assertions/use-case-mappings/test/FunctionCallInputs.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+import {Protocol, FunctionCallInputsAssertion} from "../src/FunctionCallInputs.sol";
+import {CredibleTest} from "credible-std/CredibleTest.sol";
+
+contract FunctionCallInputsTest is CredibleTest, Test {
+    Protocol public protocol;
+
+    function setUp() public {
+        // Deploy the contract
+        protocol = new Protocol();
+    }
+
+    function test_assertionFunctionCallInputs() public {
+        protocol.mint(address(0x1), 100);
+        cl.addAssertion(
+            "FunctionCallInputsAssertion",
+            address(protocol),
+            type(FunctionCallInputsAssertion).creationCode,
+            abi.encode(protocol)
+        );
+        vm.prank(address(0x1));
+        cl.validate(
+            "FunctionCallInputsAssertion",
+            address(protocol),
+            0,
+            abi.encodeWithSelector(Protocol.transfer.selector, address(0x2), 100)
+        );
+    }
+}

--- a/assertions/use-case-mappings/test/ReadLogs.t.sol
+++ b/assertions/use-case-mappings/test/ReadLogs.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+import {Protocol, ReadLogsAssertion} from "../src/ReadLogs.sol";
+import {CredibleTest} from "credible-std/CredibleTest.sol";
+
+contract ReadLogsTest is CredibleTest, Test {
+    Protocol public protocol;
+
+    function setUp() public {
+        protocol = new Protocol();
+    }
+
+    function test_assertionReadLogs() public {
+        protocol.mint(address(0x1), 100);
+        cl.addAssertion(
+            "ReadLogsAssertion", address(protocol), type(ReadLogsAssertion).creationCode, abi.encode(protocol)
+        );
+        vm.prank(address(0x1));
+        cl.validate(
+            "ReadLogsAssertion",
+            address(protocol),
+            0,
+            abi.encodeWithSelector(Protocol.transfer.selector, address(0x2), 100)
+        );
+    }
+}

--- a/assertions/use-case-mappings/test/StateChanges.t.sol
+++ b/assertions/use-case-mappings/test/StateChanges.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {CredibleTest} from "credible-std/CredibleTest.sol";
+import {Test} from "forge-std/Test.sol";
+
+import {MonotonicallyIncreasingValue, StateChangesAssertion} from "../src/StateChanges.sol";
+
+contract StateChangesTest is CredibleTest, Test {
+    MonotonicallyIncreasingValue public protocol;
+
+    function setUp() public {
+        protocol = new MonotonicallyIncreasingValue();
+    }
+
+    function test_assertionStateChanges() public {
+        cl.addAssertion(
+            "StateChangesAssertion", address(protocol), type(StateChangesAssertion).creationCode, abi.encode(protocol)
+        );
+
+        vm.prank(address(0x1));
+        cl.validate(
+            "StateChangesAssertion",
+            address(protocol),
+            0,
+            abi.encodeWithSelector(MonotonicallyIncreasingValue.setValue.selector, 1)
+        );
+    }
+}

--- a/assertions/use-case-mappings/test/StorageLookup.t.sol
+++ b/assertions/use-case-mappings/test/StorageLookup.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {CredibleTest} from "credible-std/CredibleTest.sol";
+import {Protocol, StorageLookupAssertion} from "../src/StorageLookup.sol";
+import {Test} from "forge-std/Test.sol";
+
+contract StorageLookupTest is CredibleTest, Test {
+    Protocol public protocol;
+
+    function setUp() public {
+        protocol = new Protocol();
+    }
+
+    function test_assertionStorageLookup() public {
+        protocol.setOwner(address(0x1));
+        cl.addAssertion(
+            "StorageLookupAssertion", address(protocol), type(StorageLookupAssertion).creationCode, abi.encode(protocol)
+        );
+        vm.prank(address(0x1));
+        cl.validate(
+            "StorageLookupAssertion",
+            address(protocol),
+            0,
+            abi.encodeWithSelector(Protocol.setOwner.selector, address(0x2))
+        );
+    }
+}


### PR DESCRIPTION
Currently the use case mappings are living in the stress-test repo. 
It makes more sense to maintain them in the assertions example repo.

This PR moved them